### PR TITLE
Moved all global variables under FG

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,0 +1,11 @@
+return {
+    ["debug_mode"] = false 
+    --[[ 
+    Fool's Gambit debug mode switch. Make sure it is on FALSE BEFORE committing to the github repo. Anything that isn't fully ready or planned for the current version should be inside an IF statement as such:
+
+    if FG.config.debug_mode then
+        {...} -- Your debug-only code here
+    end
+    
+    ]]
+}

--- a/content/aux_functions.lua
+++ b/content/aux_functions.lua
@@ -1,4 +1,4 @@
-function is_alternate(card,table)
+function FG.is_alternate(card,table)
     for k, v in pairs(table) do
         if card == v then
             return "v"
@@ -15,7 +15,7 @@ key is the provided card key.
 table is the reference table to look up.
 passing key or value, and returns the other.
 ]] 
-function get_equivalent(key,table,passing)
+function FG.get_equivalent(key,table,passing)
 	if passing == ("k" or "K" or "Key" or "key") then -- passing key, returning value
 		for k,v in pairs(table) do
 			if k == key then return v end
@@ -31,8 +31,8 @@ end
 -- key is the provided card key.
 -- card is the card instance you are dealing with. 99% of the time it will be just card (the one provided you by the function)
 -- table is the reference table to look up and compare.
-function alternate_card(key,card,table) 
-	local convert = get_equivalent(key,table,is_alternate(key,table))
+function FG.alternate_card(key,card,table) 
+	local convert = FG.get_equivalent(key,table,FG.is_alternate(key,table))
 	local new_card = create_card('Joker', G.jokers, false, nil, true, false, convert, nil)
 	new_card:add_to_deck()
 	G.jokers:emplace(new_card)
@@ -46,7 +46,7 @@ function alternate_card(key,card,table)
 	card:start_dissolve(nil,false,0,true)
 end
 
-function flip_editions(card)
+function FG.flip_editions(card)
 	if card.edition then
 		if card.edition.negative then
 			card:set_edition(nil, true)
@@ -65,7 +65,7 @@ function flip_editions(card)
 end
 
 -- UNFINISHED !!!
-function change_pace()
+function FG.change_pace()
 	if common_alt.default_weight > 0 then
 		sendInfoMessage("Regular", "MyInfoLogger")
 	common_alt.default_weight = 0

--- a/content/consumeables.lua
+++ b/content/consumeables.lua
@@ -41,7 +41,7 @@ SMODS.Consumable{
     can_use = function(self, card)
         if G.STATE ~= G.STATES.HAND_PLAYED and G.STATE ~= G.STATES.DRAW_TO_HAND and G.STATE ~= G.STATES.PLAY_TAROT or
             any_state then
-            if #G.jokers.highlighted == 1 and is_alternate(G.jokers.highlighted[1].config.center_key,joker_equivalents) == "v" then
+            if #G.jokers.highlighted == 1 and FG.is_alternate(G.jokers.highlighted[1].config.center_key,FG.joker_equivalents) == "v" then
                 return true
             end
         end
@@ -52,7 +52,7 @@ SMODS.Consumable{
             trigger = 'after',
             delay = 0.4,
             func = function()
-                    alternate_card(G.jokers.highlighted[1].config.center_key, G.jokers.highlighted[1], joker_equivalents)
+                    FG.alternate_card(G.jokers.highlighted[1].config.center_key, G.jokers.highlighted[1], FG.joker_equivalents)
                 return true
             end
         }))
@@ -76,7 +76,7 @@ SMODS.Consumable{
     can_use = function(self, card)
         if G.STATE ~= G.STATES.HAND_PLAYED and G.STATE ~= G.STATES.DRAW_TO_HAND and G.STATE ~= G.STATES.PLAY_TAROT or
             any_state then
-            if #G.jokers.highlighted == 1 and is_alternate(G.jokers.highlighted[1].config.center_key,joker_equivalents) == "k" then
+            if #G.jokers.highlighted == 1 and FG.is_alternate(G.jokers.highlighted[1].config.center_key,FG.joker_equivalents) == "k" then
                 return true
             end
         end
@@ -87,7 +87,7 @@ SMODS.Consumable{
             trigger = 'after',
             delay = 0.4,
             func = function()
-                    alternate_card(G.jokers.highlighted[1].config.center_key, G.jokers.highlighted[1], joker_equivalents)
+                    FG.alternate_card(G.jokers.highlighted[1].config.center_key, G.jokers.highlighted[1], FG.joker_equivalents)
                 return true
             end
         }))
@@ -150,7 +150,7 @@ SMODS.Consumable{
         for i in ipairs(G.jokers.cards) do
             currentJoker = G.jokers.cards[i]
             if currentJoker.rarity == 1 then
-                alternate_card(currentJoker)
+                FG.alternate_card(currentJoker)
             end
         end
     return true
@@ -160,8 +160,8 @@ SMODS.Consumable{
 				func = function()
 					for i in ipairs(G.jokers.cards) do
 						local currentCard = G.jokers.cards[i]
-                        if is_alternate(currentCard.config.center_key, joker_equivalents) == "k" and currentCard.config.center.rarity == 1 then
-                            alternate_card(currentCard.config.center_key, currentCard, joker_equivalents)
+                        if FG.is_alternate(currentCard.config.center_key, FG.joker_equivalents) == "k" and currentCard.config.center.rarity == 1 then
+                            FG.alternate_card(currentCard.config.center_key, currentCard, FG.joker_equivalents)
                         end
 					end
                     return true
@@ -187,7 +187,7 @@ SMODS.Consumable{
         for i in ipairs(G.jokers.cards) do
             currentJoker = G.jokers.cards[i]
             if currentJoker.rarity == 1 then
-                alternate_card(currentJoker)
+                FG.alternate_card(currentJoker)
             end
         end
     return true
@@ -197,8 +197,8 @@ SMODS.Consumable{
 				func = function()
 					for i in ipairs(G.jokers.cards) do
 						local currentCard = G.jokers.cards[i]
-                        if is_alternate(currentCard.config.center_key, joker_equivalents) == "k" and currentCard.config.center.rarity == 2 then
-                            alternate_card(currentCard.config.center_key, currentCard, joker_equivalents)
+                        if FG.is_alternate(currentCard.config.center_key, FG.joker_equivalents) == "k" and currentCard.config.center.rarity == 2 then
+                            FG.alternate_card(currentCard.config.center_key, currentCard, FG.joker_equivalents)
                         end
 					end
                     return true
@@ -224,7 +224,7 @@ SMODS.Consumable{
         for i in ipairs(G.jokers.cards) do
             currentJoker = G.jokers.cards[i]
             if currentJoker.rarity == 1 then
-                alternate_card(currentJoker)
+                FG.alternate_card(currentJoker)
             end
         end
     return true
@@ -234,8 +234,8 @@ SMODS.Consumable{
 				func = function()
 					for i in ipairs(G.jokers.cards) do
 						local currentCard = G.jokers.cards[i]
-                        if is_alternate(currentCard.config.center_key, joker_equivalents) == "k" and currentCard.config.center.rarity == 3 then
-                            alternate_card(currentCard.config.center_key, currentCard, joker_equivalents)
+                        if FG.is_alternate(currentCard.config.center_key, FG.joker_equivalents) == "k" and currentCard.config.center.rarity == 3 then
+                            FG.alternate_card(currentCard.config.center_key, currentCard, FG.joker_equivalents)
                         end
 					end
                     return true

--- a/content/editions.lua
+++ b/content/editions.lua
@@ -1,4 +1,4 @@
-edition_equivalents = {
+FG.edition_equivalents = {
 	["e_polychrome"] = "e_fg_polychrome",
 	["e_negative"] = "e_fg_negative",
 	["e_holographic"] = "e_fg_holographic",

--- a/content/enhancements.lua
+++ b/content/enhancements.lua
@@ -1,4 +1,4 @@
-enhancement_equivalents = {
+FG.enhancement_equivalents = {
 ["m_glass"] = "m_fg_glass",
 }
 

--- a/content/jokers.lua
+++ b/content/jokers.lua
@@ -26,7 +26,7 @@ SMODS.Atlas {
 	py = 95
 }
 -- All joker equivalents. Format is: original <> alternate
-joker_equivalents = {
+FG.joker_equivalents = {
 	-- Mod jokers
 	["j_fg_flipped_script"] = "j_fg_flipped_script_alt",
 	["j_fg_concert"] = "j_fg_concertalt",
@@ -69,6 +69,7 @@ joker_equivalents = {
 --------------------
 ---SPECIAL JOKERS---
 --------------------
+if FG.config.debug_mode then
 -- Change of pace
 SMODS.Joker {
 	key = 'change_of_pace',
@@ -79,7 +80,7 @@ SMODS.Joker {
 	cost = 8,
 	calculate = function(self, card, context)
 		if context.selling_self then
-			for k, v in pairs(joker_equivalents) do
+			for k, v in pairs(FG.joker_equivalents) do
 				if not string.find(k, '_fg_') then
 				
 					sendInfoMessage(k, "MyInfoLogger")
@@ -122,8 +123,8 @@ SMODS.Joker {
 				func = function()
 					for i in ipairs(G.jokers.cards) do
 						local currentCard = G.jokers.cards[i]
-                        if is_alternate(currentCard.config.center_key, joker_equivalents) == "v" then
-                            alternate_card(currentCard.config.center_key, card, joker_equivalents)
+                        if FG.FG.is_alternate(currentCard.config.center_key, FG.joker_equivalents) == "v" then
+                            FG.FG.alternate_card(currentCard.config.center_key, card, FG.joker_equivalents)
                             currentCard:start_dissolve(nil,false,0,true)
                         end
 					end
@@ -148,8 +149,8 @@ SMODS.Joker {
 				func = function()
 					for i in ipairs(G.jokers.cards) do
 						local currentCard = G.jokers.cards[i]
-                        if is_alternate(currentCard.config.center_key, joker_equivalents) == "k" then
-                            alternate_card(currentCard.config.center_key, card, joker_equivalents)
+                        if FG.is_alternate(currentCard.config.center_key, FG.joker_equivalents) == "k" then
+                            FG.alternate_card(currentCard.config.center_key, card, FG.joker_equivalents)
                             currentCard:start_dissolve(nil,false,0,true)		
                         end
 					end
@@ -447,6 +448,7 @@ end
 end
 end
 }
+end
 ---------------------
 ---STANDARD JOKERS---
 ---------------------

--- a/main.lua
+++ b/main.lua
@@ -1,6 +1,7 @@
+FG = {
+} -- Every global variable/function this mods uses should go under FG.<whatever_the_heck>
+FG.config = SMODS.current_mod.config
 
--- This is in preparation for file splitting. I'll do that later. - Jogla
--- im splitting jokers and stuff into sections to make this easier later - jenku
 local mod_contents = {
 	"aux_functions",
 	"jokers",


### PR DESCRIPTION
To prevent other modders from accidentally messing up any of our variables or functions, they all have been moved under a FG prefix, much like `SMODS.<something>`. An example would be `joker_equivalents` now being `FG.joker_equivalents`.

This change includes: 
- `joker_equivalents` (table)
- `enhancement_equivalents` (table)
- `edition_equivalents`, (table)
- `is_alternate` (function)
- `get_equivalent` (function)
- `alternate_card` (function)
- `flip_editions` (function)
- `change_pace` (function)

**This hasn't been fully tested, so I'd suggest someone to go through every single file and check there isn't anything using the old names**